### PR TITLE
Replace subprocess with pyperclip clipboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ With one command, you can include your entire codebase, or just selected files, 
 - **Combine your entire project or selected files** using flexible file patterns.
 - **Easily exclude files or directories** from the output.
 - **Clear file boundaries** thanks to auto-generated headers.
-- **macOS clipboard integration:** result is ready to paste instantly.
+- **Clipboard integration:** result is automatically copied for easy pasting.
 - **Fast and lightweight**—works with projects of any size.
 
 
@@ -42,7 +42,7 @@ With one command, you can include your entire codebase, or just selected files, 
   # FILE: path/to/your/file.ext
   # ===============================================================
   ```
-* On macOS, copies the result to your clipboard for easy pasting into LLM interfaces.
+* Automatically copies the result to your clipboard for easy pasting into LLM interfaces.
 
 
 

--- a/promptify_ai/cli.py
+++ b/promptify_ai/cli.py
@@ -2,8 +2,8 @@ import argparse
 import fnmatch
 import os
 from pathlib import Path
-import subprocess
 import shutil
+import pyperclip
 
 
 def gather_files(source_dir: Path, patterns, exclude_pattern=None):
@@ -30,11 +30,13 @@ def write_output(files, output_file: Path):
 
 
 def copy_to_clipboard(output_file: Path):
-    if shutil.which("pbcopy"):
-        subprocess.run(["pbcopy"], input=output_file.read_bytes())
+    try:
+        pyperclip.copy(output_file.read_text(encoding="utf-8"))
         print(f"Output written to '{output_file}' and copied to clipboard.")
-    else:
-        print(f"Output written to '{output_file}'. (pbcopy not available)")
+    except pyperclip.PyperclipException:
+        print(
+            f"Output written to '{output_file}'. (pyperclip could not access the clipboard)"
+        )
 
 
 def parse_args(argv=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.8"
+dependencies = ["pyperclip>=1.8"]
 
 [project.scripts]
 promptify = "promptify_ai.cli:main"


### PR DESCRIPTION
## Summary
- drop subprocess-based pbcopy usage
- use `pyperclip` for clipboard support
- mention clipboard integration in README
- require `pyperclip` in project dependencies

## Testing
- `pip install pyperclip`
- `pip install -e .`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687035d702b08327a4e3ae0e569d5a89