### PR TITLE
Add tests for project tree feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ With one command, you can include your entire codebase, or just selected files, 
 - **Combine your entire project or selected files** using flexible file patterns, with support for multiple patterns specified separately.
 - **Easily exclude files or directories** from the output.
 - **Clear file boundaries** thanks to auto-generated headers.
+- **Optional project tree overview** for quick context of your directory structure.
 - **Clipboard integration:** result is automatically copied for easy pasting.
 - **Fast and lightweight**—works with projects of any size.
 
@@ -25,6 +26,8 @@ With one command, you can include your entire codebase, or just selected files, 
 
 # Collect files from 'myapp/', output to 'llm_context.txt', using custom patterns and excluding a folder
  promptify -s myapp -o llm_context.txt -p '*.md' '*.js' -e 'docs'
+# Include files under 'app/src' and add a project tree from its parent directory
+ promptify -s app/src -o prompt.llm -t app
 
 # See all available options
  promptify -h
@@ -35,12 +38,13 @@ With one command, you can include your entire codebase, or just selected files, 
 
 * Recursively scans the specified directory for files matching your patterns.
 * Skips files or directories you choose to exclude.
-* Concatenates each file’s content into a single output file, with a clear header before each file:
+* Concatenates each file’s content into a single output file, preceded by an optional project tree.
+* Files are clearly marked:
 
   ```
-  # ===============================================================
-  # FILE: path/to/your/file.ext
-  # ===============================================================
+  # === FILE START: path/to/your/file.ext ===
+  ...file content...
+  # === FILE END ===
   ```
 * Automatically copies the result to your clipboard for easy pasting into LLM interfaces.
 

--- a/tests/test_promptify.py
+++ b/tests/test_promptify.py
@@ -1,0 +1,73 @@
+import os
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from pathlib import Path
+import pyperclip
+import pytest
+
+from promptify_ai.cli import _build_tree_lines, Promptify, parse_args
+
+
+def test_build_tree_lines(tmp_path):
+    app = tmp_path / "app"
+    src = app / "src"
+    sub = src / "sub"
+    sub.mkdir(parents=True)
+    (src / "file1.txt").write_text("a")
+    (sub / "file2.txt").write_text("b")
+
+    lines = _build_tree_lines(app)
+    assert lines == [
+        "└── src",
+        "    ├── file1.txt",
+        "    └── sub",
+        "        └── file2.txt",
+    ]
+
+
+def test_promptify_default_tree(tmp_path, monkeypatch):
+    app = tmp_path / "app"
+    src = app / "src"
+    sub = src / "sub"
+    sub.mkdir(parents=True)
+    f1 = src / "f1.txt"
+    f2 = sub / "f2.txt"
+    f1.write_text("hello")
+    f2.write_text("bye")
+
+    out = tmp_path / "out.llm"
+
+    monkeypatch.setattr(pyperclip, "copy", lambda text: None)
+
+    prompt = Promptify(source=src, output=out, patterns=["*.txt"], exclude=None)
+    prompt.run()
+
+    data = out.read_text()
+    assert "# === PROJECT TREE:" in data
+    assert "└── src" in data
+    assert "f1.txt" in data and "f2.txt" in data
+    assert data.count("# === FILE START:") == 2
+    assert prompt.tree_dir == app
+
+
+def test_promptify_custom_tree(tmp_path, monkeypatch):
+    app = tmp_path / "app"
+    src = app / "src"
+    sub = src / "sub"
+    sub.mkdir(parents=True)
+    (src / "f.txt").write_text("hi")
+
+    custom_tree = tmp_path
+    out = tmp_path / "out.llm"
+
+    monkeypatch.setattr(pyperclip, "copy", lambda text: None)
+
+    args = parse_args(["-s", str(src), "-o", str(out), "-t", str(custom_tree)])
+    prompt = Promptify(
+        Path(args.source), Path(args.output), args.pattern, args.exclude or None, Path(args.tree)
+    )
+    prompt.run()
+
+    data = out.read_text()
+    assert f"# === PROJECT TREE: {custom_tree}" in data
+    assert prompt.tree_dir == custom_tree


### PR DESCRIPTION
## Summary
- test `_build_tree_lines`
- test default and custom tree directories through `Promptify`

## Testing
- `python -m compileall -q .`
- `pytest -q`
- `python -m promptify_ai.cli -s promptify_ai -o sample.llm` (pyperclip warning expected)


------
https://chatgpt.com/codex/tasks/task_e_687041b3295c832786a44a95a0384a77