### PR TITLE
Rewrite tests with pytest

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,72 +1,65 @@
-import os
 from pathlib import Path
-import tempfile
-import unittest
 from unittest.mock import patch
 
-from promptify_ai.cli import FileCollector, PromptWriter, parse_args, Promptify
+import pytest
+
+from promptify_ai.cli import FileCollector, PromptWriter, Promptify, parse_args
 
 
-class TestFileCollector(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-        base = Path(self.temp_dir.name)
-        (base / "a.py").write_text("print('a')")
-        (base / "b.txt").write_text("text")
-        sub = base / "sub"
-        sub.mkdir()
-        (sub / "c.py").write_text("print('c')")
-        (sub / "ignore.py").write_text("print('ignore')")
-        ignored_dir = base / "ignored"
-        ignored_dir.mkdir()
-        (ignored_dir / "d.py").write_text("print('d')")
-
-    def tearDown(self):
-        self.temp_dir.cleanup()
-
-    def test_collect_with_exclude(self):
-        base = Path(self.temp_dir.name)
-        collector = FileCollector(base, ["*.py"], "ignore*")
-        files = collector.collect()
-        relative = [f.relative_to(base).as_posix() for f in files]
-        self.assertEqual(
-            relative,
-            ["a.py", "sub/c.py"],
-        )
-
-    def test_collect_multiple_patterns(self):
-        base = Path(self.temp_dir.name)
-        collector = FileCollector(base, ["*.py", "*.txt"])
-        files = collector.collect()
-        relative = [f.relative_to(base).as_posix() for f in files]
-        self.assertEqual(
-            relative,
-            ["a.py", "b.txt", "ignored/d.py", "sub/c.py", "sub/ignore.py"],
-        )
+@pytest.fixture
+def sample_dir(tmp_path: Path) -> Path:
+    base = tmp_path
+    (base / "a.py").write_text("print('a')")
+    (base / "b.txt").write_text("text")
+    sub = base / "sub"
+    sub.mkdir()
+    (sub / "c.py").write_text("print('c')")
+    (sub / "ignore.py").write_text("print('ignore')")
+    ignored_dir = base / "ignored"
+    ignored_dir.mkdir()
+    (ignored_dir / "d.py").write_text("print('d')")
+    return base
 
 
-class TestPromptWriter(unittest.TestCase):
-    def test_write_headers_multiple_files(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            base = Path(tmpdir)
-            file1 = base / "file1.txt"
-            file2 = base / "file2.txt"
-            file1.write_text("hello")
-            file2.write_text("world")
-            out = base / "out.llm"
-            writer = PromptWriter(out)
-            writer.write([file1, file2], base)
-            content = out.read_text()
-            self.assertEqual(content.count("# === FILE START:"), 2)
-            self.assertIn(f"# === FILE START: {file1}", content)
-            self.assertIn("hello", content)
-            self.assertIn(f"# === FILE START: {file2}", content)
-            self.assertIn("world", content)
+def test_filecollector_with_exclude(sample_dir: Path):
+    collector = FileCollector(sample_dir, ["*.py"], "ignore*")
+    files = collector.collect()
+    relative = [f.relative_to(sample_dir).as_posix() for f in files]
+    assert relative == ["a.py", "sub/c.py"]
 
 
-class TestParseArgs(unittest.TestCase):
-    def test_custom_args(self):
-        args = parse_args([
+def test_filecollector_multiple_patterns(sample_dir: Path):
+    collector = FileCollector(sample_dir, ["*.py", "*.txt"])
+    files = collector.collect()
+    relative = [f.relative_to(sample_dir).as_posix() for f in files]
+    assert relative == [
+        "a.py",
+        "b.txt",
+        "ignored/d.py",
+        "sub/c.py",
+        "sub/ignore.py",
+    ]
+
+
+def test_promptwriter_headers(tmp_path: Path):
+    file1 = tmp_path / "file1.txt"
+    file2 = tmp_path / "file2.txt"
+    file1.write_text("hello")
+    file2.write_text("world")
+    out = tmp_path / "out.llm"
+    writer = PromptWriter(out)
+    writer.write([file1, file2], tmp_path)
+    content = out.read_text()
+    assert content.count("# === FILE START:") == 2
+    assert f"# === FILE START: {file1}" in content
+    assert "hello" in content
+    assert f"# === FILE START: {file2}" in content
+    assert "world" in content
+
+
+def test_parse_args_custom():
+    args = parse_args(
+        [
             "-s",
             "src",
             "-o",
@@ -78,58 +71,49 @@ class TestParseArgs(unittest.TestCase):
             "venv",
             "-i",
             "do something",
-        ])
-        self.assertEqual(args.source, "src")
-        self.assertEqual(args.output, "out.txt")
-        self.assertEqual(args.pattern, ["*.txt", "*.py"])
-        self.assertEqual(args.exclude, "venv")
-        self.assertEqual(args.instruction, "do something")
-
-    def test_defaults(self):
-        args = parse_args([])
-        self.assertEqual(args.source, "src")
-        self.assertEqual(args.output, "prompt.llm")
-        self.assertEqual(args.pattern, ["*.py"])
-        self.assertEqual(args.exclude, "")
-        self.assertIsNone(args.instruction)
+        ]
+    )
+    assert args.source == "src"
+    assert args.output == "out.txt"
+    assert args.pattern == ["*.txt", "*.py"]
+    assert args.exclude == "venv"
+    assert args.instruction == "do something"
 
 
-class TestPromptifyIntegration(unittest.TestCase):
-    def test_run_writes_output(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            base = Path(tmpdir)
-            src = base / "src"
-            src.mkdir()
-            file1 = src / "x.py"
-            file1.write_text("print('x')")
-            out = base / "out.llm"
-            prompt = Promptify(src, out, ["*.py"], instruction="do it")
-            with patch.object(prompt.clipboard, "copy") as mock_copy:
-                prompt.run()
-                mock_copy.assert_called_once_with(out)
-            self.assertTrue(out.exists())
-            text = out.read_text()
-            self.assertIn("x.py", text)
-            self.assertIn("do it", text.splitlines()[1])
-
-    def test_main_invocation(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            base = Path(tmpdir)
-            src = base / "app"
-            src.mkdir()
-            (src / "y.py").write_text("print('y')")
-            out = base / "context.llm"
-            with patch("promptify_ai.cli.Promptify") as MockPromptify:
-                instance = MockPromptify.return_value
-                from promptify_ai.cli import main
-
-                main(["-s", str(src), "-o", str(out), "-p", "*.py", "-i", "inst"])
-
-                MockPromptify.assert_called_once_with(
-                    src, out, ["*.py"], None, None, "inst"
-                )
-                instance.run.assert_called_once()
+def test_parse_args_defaults():
+    args = parse_args([])
+    assert args.source == "src"
+    assert args.output == "prompt.llm"
+    assert args.pattern == ["*.py"]
+    assert args.exclude == ""
+    assert args.instruction is None
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_promptify_run(tmp_path: Path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.py").write_text("print('x')")
+    out = tmp_path / "out.llm"
+    prompt = Promptify(src, out, ["*.py"], instruction="do it")
+    with patch.object(prompt.clipboard, "copy") as mock_copy:
+        prompt.run()
+        mock_copy.assert_called_once_with(out)
+    assert out.exists()
+    text = out.read_text()
+    assert "x.py" in text
+    assert "do it" in text.splitlines()[1]
+
+
+def test_main_invocation(tmp_path: Path):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "y.py").write_text("print('y')")
+    out = tmp_path / "context.llm"
+    with patch("promptify_ai.cli.Promptify") as MockPromptify:
+        instance = MockPromptify.return_value
+        from promptify_ai.cli import main
+
+        main(["-s", str(src), "-o", str(out), "-p", "*.py", "-i", "inst"])
+
+        MockPromptify.assert_called_once_with(src, out, ["*.py"], None, None, "inst")
+        instance.run.assert_called_once()

--- a/tests/test_promptify.py
+++ b/tests/test_promptify.py
@@ -1,6 +1,3 @@
-import os
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from pathlib import Path
 import pyperclip
 import pytest


### PR DESCRIPTION
## Summary
- migrate all tests to pytest
- clean up pytest imports and remove old unittest code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687acd32e6b4832786478c6caebf304a