### PR TITLE
Fix prompt file optional output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ With one command, you can include your entire codebase, or just selected files, 
 
 * Recursively scans the specified directory for files matching your patterns.
 * Skips files or directories you choose to exclude.
-* Concatenates each file’s content into a single output file, preceded by an optional project tree.
+* Concatenates each file’s content into a single prompt, optionally saved to a file, preceded by a project tree.
 * Files are clearly marked:
 
   ```


### PR DESCRIPTION
## Summary
- avoid generating a file unless `-o` is specified
- revert README example back to `.llm`
- return text from `PromptWriter` and update clipboard handling
- adjust CLI and tests for new optional output behaviour

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ad2fb94ac83278cc88cb68f9453de