### PR TITLE
Clarify prompt output layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ With one command, you can include your entire codebase, or just selected files, 
 * Files are clearly marked:
 
   ```
-  # === FILE START: path/to/your/file.ext ===
+  # === BEGIN FILE: path/to/your/file.ext ===
   ...file content...
-  # === FILE END ===
+  # === END FILE ===
   ```
 * Automatically copies the result to your clipboard for easy pasting into LLM interfaces.
 

--- a/promptify_ai/cli.py
+++ b/promptify_ai/cli.py
@@ -60,13 +60,13 @@ class FileCollector:
 class PromptWriter:
     """Write gathered files to a single output file or return the prompt text."""
 
-    FILE_START = "# === FILE START: {file} ===\n"
-    FILE_END = "# === FILE END ===\n"
-    TREE_START = "# === PROJECT TREE: {dir} ===\n"
+    FILE_START = "# === BEGIN FILE: {file} ===\n"
+    FILE_END = "# === END FILE ===\n"
+    TREE_START = "# === BEGIN PROJECT TREE: {dir} ===\n"
     TREE_END = "# === END PROJECT TREE ===\n"
     INSTRUCTION_HEADER = "USER_REQUEST\n"
-    TREE_HEADER = "TREE\n"
-    CODE_HEADER = "CODE\n"
+    TREE_HEADER = "PROJECT TREE\n"
+    FILES_HEADER = "FILES\n"
 
     def __init__(self, output_file: Optional[Path]) -> None:
         self.output_file = output_file
@@ -86,7 +86,7 @@ class PromptWriter:
         if instruction:
             self._write_instruction(out, instruction)
         self._write_tree(out, tree_dir)
-        out.write(self.CODE_HEADER)
+        out.write(self.FILES_HEADER)
         for file in files:
             out.write(self.FILE_START.format(file=file))
             out.write(file.read_text(encoding="utf-8"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,10 +68,10 @@ def test_promptwriter_headers(tmp_path: Path):
     writer = PromptWriter(out)
     writer.write([file1, file2], tmp_path)
     content = out.read_text()
-    assert content.count("# === FILE START:") == 2
-    assert f"# === FILE START: {file1}" in content
+    assert content.count("# === BEGIN FILE:") == 2
+    assert f"# === BEGIN FILE: {file1}" in content
     assert "hello" in content
-    assert f"# === FILE START: {file2}" in content
+    assert f"# === BEGIN FILE: {file2}" in content
     assert "world" in content
 
 

--- a/tests/test_promptify.py
+++ b/tests/test_promptify.py
@@ -57,10 +57,10 @@ def test_promptify_default_tree(tmp_path, monkeypatch):
     prompt.run()
 
     data = out.read_text()
-    assert "# === PROJECT TREE:" in data
+    assert "# === BEGIN PROJECT TREE:" in data
     assert "└── src" in data
     assert "f1.txt" in data and "f2.txt" in data
-    assert data.count("# === FILE START:") == 2
+    assert data.count("# === BEGIN FILE:") == 2
     assert prompt.tree_dir == app
 
 
@@ -83,7 +83,7 @@ def test_promptify_custom_tree(tmp_path, monkeypatch):
     prompt.run()
 
     data = out.read_text()
-    assert f"# === PROJECT TREE: {custom_tree}" in data
+    assert f"# === BEGIN PROJECT TREE: {custom_tree}" in data
     assert prompt.tree_dir == custom_tree
 
 
@@ -103,7 +103,7 @@ def test_promptify_with_instruction(tmp_path, monkeypatch):
     lines = out.read_text().splitlines()
     assert lines[0] == "USER_REQUEST"
     assert lines[1] == "say hi"
-    assert "CODE" in lines
+    assert "FILES" in lines
 
 
 def test_promptify_no_output(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- improve output separators in PromptWriter
- adjust documentation snippet
- update tests for new markers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ada96bf908327bcc62eb43d45712d