### PR TITLE
Change default tree path to cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ pip install promptify-ai
 # Collect files from 'myapp/' and output to 'llm_context.txt'
 promptify -s myapp -o llm_context.txt -p '*.md' '*.js' -e 'docs'
 
-# Include files under 'app/src' and add a project tree from its parent directory
+# Include files under 'app/src' and add a project tree from 'app' (the default
+# tree is generated from the current directory)
 promptify -s app/src -o prompt.llm -t app
 
 # See all available options

--- a/promptify_ai/cli.py
+++ b/promptify_ai/cli.py
@@ -140,7 +140,10 @@ class Promptify:
         self.collector = FileCollector(source, patterns, exclude)
         self.writer = PromptWriter(output)
         self.clipboard = ClipboardManager()
-        self.tree_dir = tree_dir or source.parent
+        # Default tree directory to the current working directory when not
+        # explicitly provided, so the project tree reflects where the command
+        # was invoked.
+        self.tree_dir = tree_dir or Path.cwd()
         self.instruction = instruction
 
     def run(self) -> None:
@@ -173,7 +176,7 @@ def parse_args(argv=None):
         "-t",
         "--tree",
         default=None,
-        help="Directory to generate the tree from (defaults to parent of source)",
+        help="Directory to generate the tree from (defaults to current directory)",
     )
     parser.add_argument(
         "-i",

--- a/tests/test_promptify.py
+++ b/tests/test_promptify.py
@@ -52,6 +52,9 @@ def test_promptify_default_tree(tmp_path, monkeypatch):
     out = tmp_path / "out.llm"
 
     monkeypatch.setattr(pyperclip, "copy", lambda text: None)
+    # Simulate running the command from the temporary directory so the default
+    # tree directory uses this location.
+    monkeypatch.chdir(tmp_path)
 
     prompt = Promptify(source=src, output=out, patterns=["*.txt"], exclude=None)
     prompt.run()
@@ -61,7 +64,7 @@ def test_promptify_default_tree(tmp_path, monkeypatch):
     assert "└── src" in data
     assert "f1.txt" in data and "f2.txt" in data
     assert data.count("# === BEGIN FILE:") == 2
-    assert prompt.tree_dir == app
+    assert prompt.tree_dir == Path.cwd()
 
 
 def test_promptify_custom_tree(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- set Promptify default project tree directory to the working directory
- clarify `--tree` help text
- document new default in README
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8c0ae7e08327af4d398836925b82