### PR TITLE
Automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Bump version and release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  bump-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install toml
+
+      - name: Bump minor version
+        id: bump
+        run: |
+          NEW_VERSION=$(python scripts/bump_minor.py)
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version bump
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -am "Bump version to ${{ steps.bump.outputs.new_version }}"
+          git tag -a v${{ steps.bump.outputs.new_version }} -m "Release ${{ steps.bump.outputs.new_version }}"
+          git push origin HEAD --follow-tags
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.bump.outputs.new_version }}
+          name: v${{ steps.bump.outputs.new_version }}
+          generate_release_notes: true

--- a/scripts/bump_minor.py
+++ b/scripts/bump_minor.py
@@ -1,0 +1,21 @@
+import re
+import pathlib
+import toml
+
+pyproject = pathlib.Path('pyproject.toml')
+data = toml.load(pyproject)
+version = data['project']['version']
+major, minor, patch = map(int, version.split('.'))
+minor += 1
+patch = 0
+new_version = f"{major}.{minor}.{patch}"
+
+data['project']['version'] = new_version
+pyproject.write_text(toml.dumps(data))
+
+init_path = pathlib.Path('promptify_ai/__init__.py')
+content = init_path.read_text()
+content = re.sub(r'__version__ = "[0-9.]+"', f'__version__ = "{new_version}"', content)
+init_path.write_text(content)
+
+print(new_version)


### PR DESCRIPTION
## Summary
- add workflow to bump minor version and create a release on each merge to `master`
- implement simple python script to bump version numbers

The release created by the new workflow automatically triggers the existing `python-publish.yml` workflow which publishes to PyPI using GitHub OIDC (Trusted Publishing), so no additional secrets are required.

## Testing
- `pip install pytest pyperclip toml`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b8d7f8f408327988b208b661c87a9