### PR TITLE
Fix UnicodeDecodeError in cli when reading files

### DIFF
--- a/promptify_ai/cli.py
+++ b/promptify_ai/cli.py
@@ -89,7 +89,7 @@ class PromptWriter:
         out.write(self.FILES_HEADER)
         for file in files:
             out.write(self.FILE_START.format(file=file))
-            out.write(file.read_text(encoding="utf-8"))
+            out.write(file.read_text(encoding="utf-8", errors="replace"))
             out.write("\n" + self.FILE_END + "\n\n")
 
     def write(self, files: Iterable[Path], tree_dir: Path, instruction: Optional[str] = None) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,16 @@ def test_promptwriter_headers(tmp_path: Path):
     assert "world" in content
 
 
+def test_promptwriter_handles_bad_utf8(tmp_path: Path):
+    bad_file = tmp_path / "bad.bin"
+    bad_file.write_bytes(b"\xff\xfehello")
+    out = tmp_path / "out.llm"
+    writer = PromptWriter(out)
+    writer.write([bad_file], tmp_path)
+    text = out.read_text()
+    assert "\ufffd" in text
+
+
 def test_parse_args_custom():
     args = parse_args(
         [


### PR DESCRIPTION
## Summary
- handle invalid UTF-8 content when reading files
- test PromptWriter with a non UTF-8 file

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d4340fe348327879dd4bff9b32716